### PR TITLE
fix: all endpoints to v2 api-gateway

### DIFF
--- a/lib/seatable_ruby/basic_info.rb
+++ b/lib/seatable_ruby/basic_info.rb
@@ -16,7 +16,7 @@ module SeatableRuby
     # for more info -> https://api.seatable.io/reference/get-base-info
 
     def basic_info
-      url = URI("https://cloud.seatable.io/dtable-server/dtables/#{dtable_uuid}")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}")
 
       https = Net::HTTP.new(url.host, url.port)
       https.use_ssl = true
@@ -31,7 +31,7 @@ module SeatableRuby
     # for more info -> https://api.seatable.io/reference/get-metadata
 
     def basic_metadata
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/metadata/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/dtables/#{dtable_uuid}/metadata/")
 
       https = Net::HTTP.new(url.host, url.port)
       https.use_ssl = true
@@ -47,7 +47,7 @@ module SeatableRuby
     # for more info -> https://api.seatable.io/reference/get-big-data-status
 
     def basic_big_data_status
-      url = URI("https://cloud.seatable.io/dtable-db/api/v1/base-info/#{dtable_uuid}/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/base-info/#{dtable_uuid}/")
 
       https = Net::HTTP.new(url.host, url.port)
       https.use_ssl = true

--- a/lib/seatable_ruby/column.rb
+++ b/lib/seatable_ruby/column.rb
@@ -19,7 +19,7 @@ module SeatableRuby
     # for more info -> https://api.seatable.io/reference/list-columns
 
     def list_columns(query_params)
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/columns")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/columns")
 
       url.query = URI.encode_www_form(query_params) # For example: it returns "?table_name=Table1&view_name=Default View"
       https = Net::HTTP.new(url.host, url.port)

--- a/lib/seatable_ruby/row.rb
+++ b/lib/seatable_ruby/row.rb
@@ -18,7 +18,7 @@ module SeatableRuby
     # for more info -> https://api.seatable.io/reference/list-rows-with-sql
 
     def list_rows_with_sql(body_params)
-      url = URI("https://cloud.seatable.io/dtable-db/api/v1/query/#{dtable_uuid}/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/sql")
 
       https = Net::HTTP.new(url.host, url.port)
       https.use_ssl = true
@@ -61,7 +61,7 @@ module SeatableRuby
     # for more info -> https://api.seatable.io/reference/add-row
 
     def append_row(body_params)
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/rows/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/rows/")
 
       https = Net::HTTP.new(url.host, url.port)
       https.use_ssl = true
@@ -82,7 +82,7 @@ module SeatableRuby
     # for more info -> https://api.seatable.io/reference/add-row
 
     def insert_row(body_params)
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/rows/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/rows/")
 
       https = Net::HTTP.new(url.host, url.port)
       https.use_ssl = true
@@ -102,7 +102,7 @@ module SeatableRuby
     # required body_params are -> { table_name: '...', row_id: '...', row: { row data }]
     # for more info -> https://api.seatable.io/reference/update-row
     def update_row(body_params)
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/rows/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/rows/")
 
       https = Net::HTTP.new(url.host, url.port)
       https.use_ssl = true
@@ -122,7 +122,7 @@ module SeatableRuby
     # required body_params are -> { table_name: '...', row_id: '...' }
     # for more info -> https://api.seatable.io/reference/delete-row
     def delete_row(body_params)
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/rows/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/rows/")
 
       https = Net::HTTP.new(url.host, url.port)
       https.use_ssl = true
@@ -164,7 +164,7 @@ module SeatableRuby
     # for more info -> https://api.seatable.io/reference/append-rows
 
     def append_rows(body_params)
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/batch-append-rows/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/rows/")
 
       https = Net::HTTP.new(url.host, url.port)
       https.use_ssl = true
@@ -184,7 +184,7 @@ module SeatableRuby
     # for more info -> https://api.seatable.io/reference/update-rows
 
     def update_rows(body_params)
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/batch-update-rows/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/rows/")
 
       https = Net::HTTP.new(url.host, url.port)
       https.use_ssl = true
@@ -205,7 +205,7 @@ module SeatableRuby
     # for more info -> https://api.seatable.io/reference/delete-rows
 
     def delete_rows(body_params)
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/batch-delete-rows/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/rows/")
 
       https = Net::HTTP.new(url.host, url.port)
       https.use_ssl = true
@@ -228,7 +228,7 @@ module SeatableRuby
     # for more info -> https://api.seatable.io/reference/lock-rows
 
     def lock_rows(body_params)
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/lock-rows/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/lock-rows/")
 
       https = Net::HTTP.new(url.host, url.port)
       https.use_ssl = true
@@ -249,7 +249,7 @@ module SeatableRuby
     # for more info -> https://api.seatable.io/reference/unlock-rows
 
     def unlock_rows(body_params)
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/unlock-rows/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/unlock-rows/")
 
       https = Net::HTTP.new(url.host, url.port)
       https.use_ssl = true

--- a/lib/seatable_ruby/version.rb
+++ b/lib/seatable_ruby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SeatableRuby
-  VERSION = "0.1.11"
+  VERSION = "0.1.12"
 end

--- a/lib/seatable_ruby/view.rb
+++ b/lib/seatable_ruby/view.rb
@@ -18,7 +18,7 @@ module SeatableRuby
     # for mor info -> https://api.seatable.io/reference/list-views
 
     def list_views(query_params)
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/views/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/views/")
 
       url.query = URI.encode_www_form(query_params)
       http = Net::HTTP.new(url.host, url.port)
@@ -41,7 +41,7 @@ module SeatableRuby
     # for mor info -> https://api.seatable.io/reference/create-view
 
     def create_view(query_params, body_params)
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/views/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/views/")
 
       url.query = URI.encode_www_form(query_params)
       http = Net::HTTP.new(url.host, url.port)
@@ -66,7 +66,7 @@ module SeatableRuby
 
     def get_view(path_params, query_params)
       view_name = (path_params[:view_name] || 'Default View').gsub(/[\s*]/, '%20')
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/views/#{view_name}/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/views/#{view_name}/")
 
       url.query = URI.encode_www_form(query_params)
       http = Net::HTTP.new(url.host, url.port)
@@ -93,7 +93,7 @@ module SeatableRuby
 
     def update_view(path_params, query_params, body_params)
       view_name = (path_params[:view_name] || 'Default View').gsub(/[\s*]/, '%20')
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/views/#{view_name}/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/views/#{view_name}/")
 
       url.query = URI.encode_www_form(query_params)
       http = Net::HTTP.new(url.host, url.port)
@@ -117,7 +117,7 @@ module SeatableRuby
     # for mor info -> https://api.seatable.io/reference/delete-view
     def delete_view(path_params, query_params)
       view_name = (path_params[:view_name] || 'Default View').gsub(/[\s*]/, '%20')
-      url = URI("https://cloud.seatable.io/dtable-server/api/v1/dtables/#{dtable_uuid}/views/#{view_name}/")
+      url = URI("https://cloud.seatable.io/api-gateway/api/v2/dtables/#{dtable_uuid}/views/#{view_name}/")
 
       url.query = URI.encode_www_form(query_params)
       http = Net::HTTP.new(url.host, url.port)


### PR DESCRIPTION
Quick fix for the SeaTable 5.3 update - all endpoints up to api-gateway v2

closes #2 